### PR TITLE
feat(coding-agent): add reproducible local Bus multiplayer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Fast in a terminal. Extensible as a runtime. Native to October Bus.
 
 **October Harness is a complete open-source coding agent built to work alone and with other agents.** Run it as an interactive terminal partner, a one-shot command, a JSON process, an RPC server, or an embedded SDK. Use October inference or bring another supported model provider.
 
-October discovers tools automatically from the public [October Bus](https://github.com/october-dev/october-bus) launcher or October Desktop. Agents can pull durable messages, acknowledge handled work, coordinate tasks, and send correlated replies. Public Bus delivery is pull-only: idle agents do not wake automatically. Desktop additionally supplies session and turn context through its hook protocol.
+October discovers tools automatically from the public [October Bus](https://github.com/october-dev/october-bus) launcher or October Desktop. Agents can pull durable messages, acknowledge handled work, coordinate tasks, and send correlated replies. Public Bus delivery can wake idle RPC and TUI sessions automatically; print and JSON runs require an explicit prompt to process inbox work. Desktop additionally supplies session and turn context through its hook protocol.
 
 October Bus is the open communication substrate. October is the runtime and control plane above it, adding the visual workspace, automatic staffing, harness selection, quota-aware routing, cross-machine operation, supervision, outcome learning, and Autopilot.
 
@@ -170,6 +170,8 @@ Bus integration is execution-gated. Public Bus requires the launcher's address, 
 
 ## Two harnesses, one Bus
 
+For a runnable example without API keys, see [Local Bus multiplayer](packages/coding-agent/examples/october-bus/README.md). It starts an isolated pinned Bus and two real SDK worker processes, verifies discovery, task completion, correlated replies, and acknowledgements, then cleans up.
+
 Start a local [October Bus](https://github.com/october-dev/october-bus), create a scope, and keep its scope token in the launching shell. In separate terminals, using the same scope:
 
 ```bash
@@ -179,7 +181,7 @@ OCTOBER_BUS_SCOPE_TOKEN=<scope-token> october-bus agent run --id planner --name 
 OCTOBER_BUS_SCOPE_TOKEN=<scope-token> october-bus agent run --id builder --name Builder --connect-to planner -- october
 ```
 
-The launcher injects execution-scoped credentials; October discovers MCP tools without a separate MCP configuration. The scope token is not passed to October. Submit a prompt to each agent: this adapter does not automatically wake an idle session. In Desktop, launch the harness in two terminal nodes on one canvas; Desktop uses its own hook contract.
+The launcher injects execution-scoped credentials; October discovers MCP tools without a separate MCP configuration. The scope token is not passed to October. Prompt the planner once; incoming public Bus messages can wake idle RPC and TUI sessions and are acknowledged after successful turn settlement. In Desktop, launch the harness in two terminal nodes on one canvas; Desktop uses its own hook contract.
 
 Ask the first agent:
 

--- a/packages/coding-agent/examples/README.md
+++ b/packages/coding-agent/examples/README.md
@@ -7,6 +7,9 @@ Example code for pi-coding-agent SDK and extensions.
 ### [sdk/](sdk/)
 Programmatic usage via `createAgentSession()`. Shows how to customize models, prompts, tools, extensions, and session management.
 
+### [october-bus/](october-bus/)
+Deterministic, credential-free multiplayer exchange between two real SDK worker processes and an isolated local October Bus, with correlated replies, acknowledgement evidence, and automatic teardown.
+
 ### [extensions/](extensions/)
 Example extensions demonstrating:
 - Lifecycle event handlers (tool interception, safety gates, context modifications)

--- a/packages/coding-agent/examples/october-bus/README.md
+++ b/packages/coding-agent/examples/october-bus/README.md
@@ -1,0 +1,143 @@
+# Local Bus multiplayer example
+
+Run two real October Harness SDK processes, `planner` and `builder`, against an isolated local [October Bus](https://github.com/october-dev/october-bus). The public faux provider drives deterministic model-to-tool calls without API keys, paid models, October Desktop, or a hosted control plane.
+
+This is a checkout-local SDK example using `createAgentSession` and the existing Bus adapters through relative `.ts` imports. It verifies the real harness runtime and Bus transport, not the stock `october` CLI entrypoint. IDs, ports, PIDs, and readiness-log order vary; the asserted exchange is fixed.
+
+## Prerequisites
+
+Use Node.js 22.19 or newer. The installation commands below support Linux and macOS on x86-64 or ARM64 and require `curl`, `tar`, and `sha256sum` or `shasum`.
+
+From a fresh Harness checkout:
+
+```bash
+npm ci --ignore-scripts
+npm run hydrate:model-data
+npm run build:offline
+```
+
+Fresh Git clones lack the ignored provider JSON. `hydrate:model-data` downloads public model metadata without credentials and writes only that data; it does not regenerate the tracked model sources. `build:offline` then builds the workspace exports without refreshing the catalog. An already hydrated checkout can omit hydration. Installation and hydration need internet access; the example itself uses loopback only.
+
+## Install the pinned public Bus
+
+Use exactly [v0.1.0-rc.4](https://github.com/october-dev/october-bus/releases/tag/v0.1.0-rc.4), protocol `0.1`. The SHA-256 values below pin the release archives, and verification happens before extraction. Keep this shell open for the run command so `bus_install` remains available.
+
+```bash
+bus_install="$(mktemp -d "${TMPDIR:-/tmp}/october-bus-install.XXXXXX")"
+(
+  set -eu
+  case "$(uname -s)/$(uname -m)" in
+    Linux/x86_64)
+      bus_platform=linux_amd64
+      bus_sha=cd2aa2ecb5f5b6a9dfe7b39e1bf7dc3ec3e43f96edbaa4f93a0838ee883fb16c ;;
+    Linux/aarch64|Linux/arm64)
+      bus_platform=linux_arm64
+      bus_sha=c083d731203657a72c8aad40b5db206324db8b339aedcf67779b283fdd2243c0 ;;
+    Darwin/x86_64)
+      bus_platform=darwin_amd64
+      bus_sha=7cedc16ff0c7df935da966b27ac2c35e6801b9bc66c20c601d066f248878ad45 ;;
+    Darwin/arm64)
+      bus_platform=darwin_arm64
+      bus_sha=21dc184e2114e8a5cce4a437ca8b9a98db0a5f9a6213ddc815d7c3186f19eea3 ;;
+    *) printf '%s\n' 'Unsupported platform for these installation commands' >&2; exit 1 ;;
+  esac
+  bus_archive="october-bus_0.1.0-rc.4_${bus_platform}.tar.gz"
+  curl --fail --location --output "$bus_install/$bus_archive" \
+    "https://github.com/october-dev/october-bus/releases/download/v0.1.0-rc.4/$bus_archive"
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s  %s\n' "$bus_sha" "$bus_install/$bus_archive" | sha256sum --check -
+  else
+    printf '%s  %s\n' "$bus_sha" "$bus_install/$bus_archive" | shasum -a 256 --check -
+  fi
+  tar -xzf "$bus_install/$bus_archive" -C "$bus_install" --strip-components=1
+  "$bus_install/october-bus" version
+)
+```
+
+Expected version: `october-bus 0.1.0-rc.4 (protocol 0.1)`. Do not substitute a development build or another prerelease: operations can differ even when the protocol version is unchanged. The runner checks the version metadata; archive integrity is checked during installation.
+
+## Run
+
+From the Harness repository root, use its pinned `tsx`:
+
+```bash
+./node_modules/.bin/tsx packages/coding-agent/examples/october-bus/run.ts \
+  --bus "$bus_install/october-bus"
+```
+
+`--bus` accepts an executable path or a command on `PATH`. Without it, the runner uses `OCTOBER_BUS_BINARY`, then `october-bus` on `PATH`. Missing or incompatible binaries produce installation instructions and exit nonzero; they never cause a successful skip.
+
+Startup order:
+
+1. Check the pinned binary; create unique data/runtime directories and start the daemon on a loopback port.
+2. Validate `run/bus.json`, its loopback address and owned PID, then require matching healthy `doctor --json` output.
+3. Create a scope using the runfile's admin token. Register planner, then builder with `connectTo: ["planner"]`.
+4. Spawn two Node workers with separate configuration directories and execution credentials. Each binds its session in RPC mode and confirms an idle/ready heartbeat.
+5. Once both workers are ready, prompt planner exactly once. Builder's turn and planner's reply turn wake through the existing Bus adapter.
+6. Collect successful settlement and acknowledgement evidence, stop workers and daemon in reverse order, and remove the runtime directories.
+
+The parent creates identities and coordinates readiness, completion, and teardown over IPC. It never forwards tasks, requests, or replies between workers. All task operations and both messages pass through the Bus from harness tool calls.
+
+## Expected exchange and evidence
+
+```text
+planner -> list_peers() -> builder discovered
+planner -> add_task(title=...) -> taskId, status=open
+planner -> message_peer(builder, mode=request, body={taskId}) -> requestId
+planner -> first turn settles
+Bus     -> builder receives request in model context; automatically starts a turn
+builder -> claim_task(taskId) -> status=claimed, claimedBy=builder
+builder -> complete_task(taskId) -> status=done
+builder -> message_peer(planner, mode=response, responseTo=requestId,
+                        body={taskId,status:"done"}) -> responseId
+builder -> turn settles; adapter acknowledges requestId
+Bus     -> planner receives response in model context; automatically starts a turn
+planner -> verifies from, to, mode, responseTo, taskId and completed status
+planner -> second turn settles; adapter acknowledges responseId
+parent  -> verifies matching IDs and both acknowledgement records; tears down
+```
+
+The workers derive task and message IDs from actual results and delivered context. In-memory faux credentials are registered in each production `ModelRuntime`; its catalog refresh has `allowModelNetwork: false`. The resource loader supplies only the Bus extension and no discovered settings, skills, prompts, or project instructions. Built-in coding tools are disabled.
+
+Output includes the daemon's PID/address, two distinct worker PIDs, and one JSON `evidence:` record per worker. Planner reports two settled turns; builder reports one. Each record includes the shared task/request/response IDs, assertion descriptions, and the exact acknowledged message ID. The adapter records acknowledgements after its `agent_settled` handler completes; invoking a tool alone is insufficient.
+
+A successful run ends with:
+
+```text
+cleanup: all owned processes exited; removed /tmp/october-bus-multiplayer-...
+PASS: discovery, task completion, correlated response, settlement and acknowledgements verified
+```
+
+Exit status is `0` only after the assertions and cleanup succeed. The workflow has a 45-second deadline, with shorter startup, subprocess, and HTTP limits. Teardown allows each owned process three seconds to exit gracefully, then sends a forced kill and waits at most five more seconds. Forced termination makes the run fail. Directories are removed only after every owned process exits. The runner never calls a global `october-bus stop` or signals a PID from an unrelated runfile.
+
+## Explicit connection failure
+
+```bash
+./node_modules/.bin/tsx packages/coding-agent/examples/october-bus/run.ts \
+  --bus "$bus_install/october-bus" --revoke-planner
+```
+
+After both workers become ready, this replaces planner's execution using the scope credential. The running planner retains its old token. Its first model-driven `list_peers` call must fail with `MCP HTTP 401`; the worker and parent report failure, tear down both workers and the daemon, and exit `1`. This is intentionally a failed workflow, not a successful test that catches and ignores a 401. It prints the cleanup line and a `FAIL:` diagnostic, never `PASS:`.
+
+## Environment and isolation
+
+| Process | Variables |
+| --- | --- |
+| Parent | Optional `OCTOBER_BUS_BINARY`; `--bus` takes precedence |
+| Daemon and doctor | Generated `OCTOBER_BUS_DATA_DIR` and `OCTOBER_BUS_RUNTIME_DIR` |
+| Each worker | `OCTOBER_BUS_ADDRESS`, `OCTOBER_BUS_MCP_URL`, `OCTOBER_BUS_AGENT_ID`, `OCTOBER_BUS_EXECUTION_ID`, `OCTOBER_BUS_AGENT_TOKEN` |
+| Each worker's local runtime | Its own `OCTOBER_CODING_AGENT_DIR`, plus `PI_OFFLINE=1` and `AWS_EC2_METADATA_DISABLED=true` |
+
+Child environments inherit only `PATH`, Windows system-directory variables when present, and language settings. Inherited Bus addresses, credentials, proxy settings, model API keys, and Node-loader options are excluded. Admin and scope tokens remain in the parent and the private daemon state; neither is exported to a worker. Token values are not logged. Existing daemons and the developer's configuration are not modified.
+
+## Troubleshooting and verification
+
+- **Missing binary or wrong release:** install the pinned archive and pass its executable through `--bus`.
+- **Missing provider JSON:** run `npm run hydrate:model-data`, then `npm run build:offline`.
+- **Unresolved workspace exports:** run the offline build from the repository root. Use the repository's `tsx`, not an unpinned `npx` download.
+- **Worker rejects its environment:** launch through `run.ts`; do not supply partial execution variables or reuse another daemon's credentials.
+- **Readiness or turn timeout:** the error includes captured worker stderr. Check local executable permissions and loopback availability. The runner tears down partial startup too.
+- **Unexpected protocol/tool shape:** check the exact Bus release. Failures name the missing tool, result, delivery, or correlation assertion.
+- **Interrupted run:** SIGINT and SIGTERM trigger owned-process cleanup and a nonzero exit. A cleanup failure retains the directory and reports failure.
+
+Run `npm run check` after changing the example. Verify the happy path exits `0`, the revoked-token path exits `1` with a `list_peers`/401 diagnostic, and neither leaves any of its reported PIDs or runtime directories behind. The downloaded installation directory is intentionally separate; remove it yourself when finished with the pinned binary.

--- a/packages/coding-agent/examples/october-bus/run.ts
+++ b/packages/coding-agent/examples/october-bus/run.ts
@@ -1,0 +1,322 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import type { Evidence, Role } from "./worker.ts";
+
+const RELEASE = "0.1.0-rc.4";
+const PROTOCOL = "0.1";
+const INSTALL =
+	"Install the checksum-verified v0.1.0-rc.4 archive as described in packages/coding-agent/examples/october-bus/README.md, then pass --bus /path/to/october-bus.";
+
+interface OwnedProcess {
+	child: ChildProcess;
+	label: string;
+	closed: boolean;
+	stdout: string;
+	stderr: string;
+	error?: Error;
+}
+
+function object(value: unknown): Record<string, unknown> {
+	assert(value && typeof value === "object" && !Array.isArray(value), "Expected a Bus/IPC object");
+	return value as Record<string, unknown>;
+}
+
+function text(value: unknown): string {
+	assert(typeof value === "string" && value.length > 0, "Expected a nonempty Bus/IPC string");
+	return value;
+}
+
+function strings(value: unknown): string[] {
+	assert(Array.isArray(value) && value.every((entry) => typeof entry === "string"), "Expected an IPC string array");
+	return value;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number, signal?: AbortSignal): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		signal?.throwIfAborted();
+		assert(Date.now() < deadline, `Timed out after ${timeoutMs}ms`);
+		await delay(25);
+	}
+	signal?.throwIfAborted();
+}
+
+async function main(): Promise<void> {
+	const { values } = parseArgs({
+		options: {
+			bus: { type: "string" },
+			"revoke-planner": { type: "boolean", default: false },
+			help: { type: "boolean" },
+		},
+		strict: true,
+	});
+	if (values.help) {
+		console.log("Usage: tsx packages/coding-agent/examples/october-bus/run.ts [--bus PATH] [--revoke-planner]");
+		console.log(INSTALL);
+		return;
+	}
+	const selected = values.bus ?? process.env.OCTOBER_BUS_BINARY ?? "october-bus";
+	const binary = /[/\\]/.test(selected) ? resolve(selected) : selected;
+	const root = mkdtempSync(join(tmpdir(), "october-bus-multiplayer-"));
+	const owned: OwnedProcess[] = [];
+	const secrets: string[] = [];
+	const workflow = new AbortController();
+	let stopping = false;
+	const timeout = setTimeout(() => workflow.abort(new Error("Bus workflow exceeded 45 seconds")), 45_000);
+	const interrupt = (): void => {
+		workflow.abort(new Error("Interrupted by SIGINT"));
+	};
+	const terminate = (): void => {
+		workflow.abort(new Error("Interrupted by SIGTERM"));
+	};
+	process.once("SIGINT", interrupt);
+	process.once("SIGTERM", terminate);
+	// Allow only platform settings. No inherited Bus, model, proxy, or Node-loader credentials/configuration.
+	const platformEnv: NodeJS.ProcessEnv = {};
+	for (const key of ["PATH", "SystemRoot", "SYSTEMROOT", "WINDIR", "LANG", "LC_ALL"]) {
+		if (process.env[key]) platformEnv[key] = process.env[key];
+	}
+	const daemonEnv = {
+		...platformEnv,
+		OCTOBER_BUS_DATA_DIR: join(root, "data"),
+		OCTOBER_BUS_RUNTIME_DIR: join(root, "run"),
+	};
+	const redact = (value: string): string =>
+		secrets.reduce((output, secret) => output.replaceAll(secret, "[redacted]"), value);
+	const launch = (
+		label: string,
+		command: string,
+		args: string[],
+		env: NodeJS.ProcessEnv,
+		persistent = false,
+		ipc = false,
+	): OwnedProcess => {
+		const child = spawn(command, args, {
+			cwd: root,
+			env,
+			stdio: ipc ? ["ignore", "pipe", "pipe", "ipc"] : ["ignore", "pipe", "pipe"],
+		});
+		const entry: OwnedProcess = { child, label, closed: false, stdout: "", stderr: "" };
+		owned.push(entry);
+		child.stdout?.on("data", (chunk: Buffer) => {
+			entry.stdout = (entry.stdout + chunk.toString()).slice(-16_384);
+		});
+		child.stderr?.on("data", (chunk: Buffer) => {
+			entry.stderr = (entry.stderr + chunk.toString()).slice(-16_384);
+		});
+		child.on("error", (error) => {
+			entry.error = error;
+			if (persistent && !stopping) workflow.abort(new Error(`${label} could not start: ${error.message}`));
+		});
+		child.on("close", (code, signal) => {
+			entry.closed = true;
+			if (persistent && !stopping)
+				workflow.abort(new Error(`${label} exited unexpectedly (${signal ?? code}): ${redact(entry.stderr)}`));
+		});
+		return entry;
+	};
+	const command = async (args: string[]): Promise<string> => {
+		const entry = launch(`bus ${args[0]}`, binary, args, daemonEnv);
+		await waitFor(() => entry.closed, 5000, workflow.signal);
+		if (entry.error) throw entry.error;
+		assert.equal(entry.child.exitCode, 0, `${entry.label} failed: ${redact(entry.stderr)}`);
+		return entry.stdout;
+	};
+	let failed: unknown;
+	try {
+		let version: string;
+		try {
+			version = (await command(["version"])).trim();
+		} catch {
+			throw new Error(`Cannot run the pinned October Bus binary. ${INSTALL}`);
+		}
+		assert.equal(
+			version,
+			`october-bus ${RELEASE} (protocol ${PROTOCOL})`,
+			`Wrong October Bus release/protocol. ${INSTALL}`,
+		);
+		console.log(`bus: ${version}`);
+		console.log(`isolation: ${root}`);
+		const daemon = launch("daemon", binary, ["start"], daemonEnv, true);
+		const runPath = join(root, "run", "bus.json");
+		await waitFor(() => existsSync(runPath), 10_000, workflow.signal);
+		const run = object(JSON.parse(readFileSync(runPath, "utf8")));
+		const address = text(run.address);
+		const adminToken = text(run.adminToken);
+		secrets.push(adminToken);
+		const url = new URL(address);
+		assert(
+			url.protocol === "http:" && url.hostname === "127.0.0.1" && url.port && url.origin === address,
+			"Isolated Bus must use a loopback HTTP origin",
+		);
+		assert.equal(run.pid, daemon.child.pid, "Runfile must belong to the daemon we started");
+		const doctor = object(JSON.parse(await command(["doctor", "--json"])));
+		assert.equal(doctor.healthy, true, "Bus doctor must report healthy");
+		assert.equal(doctor.protocolVersion, PROTOCOL);
+		assert.equal(doctor.runtimeVersion, RELEASE);
+		assert.equal(doctor.address, address);
+		assert.equal(doctor.pid, daemon.child.pid);
+		assert.equal(doctor.runtimeDirectory, daemonEnv.OCTOBER_BUS_RUNTIME_DIR);
+		assert.equal(doctor.dataDirectory, daemonEnv.OCTOBER_BUS_DATA_DIR);
+		console.log(`daemon: pid=${daemon.child.pid} address=${address} doctor=healthy`);
+		const api = async (route: string, token: string, input: unknown): Promise<Record<string, unknown>> => {
+			const response = await fetch(`${address}${route}`, {
+				method: "POST",
+				headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+				body: JSON.stringify(input),
+				redirect: "error",
+				signal: AbortSignal.any([workflow.signal, AbortSignal.timeout(5000)]),
+			});
+			assert(response.ok, `Bus ${route}: HTTP ${response.status}`);
+			return object(object(await response.json()).result);
+		};
+		const scopeToken = text((await api("/v1/scopes", adminToken, { id: "multiplayer-example" })).scopeToken);
+		secrets.push(scopeToken);
+		const registrations = new Map<Role, Record<string, unknown>>();
+		for (const role of ["planner", "builder"] as const) {
+			const registration = await api("/v1/agents", scopeToken, {
+				id: role,
+				displayName: role,
+				connectTo: role === "builder" ? ["planner"] : [],
+				leaseMs: 300_000,
+			});
+			secrets.push(text(registration.agentToken));
+			registrations.set(role, registration);
+		}
+		const workers: { role: Role; process: OwnedProcess; ready: boolean; evidence?: Evidence }[] = [];
+		for (const role of ["planner", "builder"] as const) {
+			const registration = registrations.get(role)!;
+			const agentDir = join(root, role);
+			mkdirSync(agentDir);
+			const entry = launch(
+				role,
+				process.execPath,
+				[
+					"--import",
+					import.meta.resolve("tsx"),
+					fileURLToPath(new URL("./worker.ts", import.meta.url)),
+					"--role",
+					role,
+				],
+				{
+					...platformEnv,
+					OCTOBER_CODING_AGENT_DIR: agentDir,
+					PI_OFFLINE: "1",
+					AWS_EC2_METADATA_DISABLED: "true",
+					OCTOBER_BUS_ADDRESS: address,
+					OCTOBER_BUS_MCP_URL: `${address}/mcp`,
+					OCTOBER_BUS_AGENT_ID: text(registration.agentId),
+					OCTOBER_BUS_EXECUTION_ID: text(registration.executionId),
+					OCTOBER_BUS_AGENT_TOKEN: text(registration.agentToken),
+				},
+				true,
+				true,
+			);
+			const worker: (typeof workers)[number] = { role, process: entry, ready: false };
+			workers.push(worker);
+			entry.child.on("message", (value: unknown) => {
+				try {
+					const message = object(value);
+					assert.equal(message.role, role);
+					assert.equal(message.pid, entry.child.pid);
+					if (message.type === "ready") {
+						assert(!worker.ready, "Worker sent duplicate readiness");
+						worker.ready = true;
+						console.log(`${role}: pid=${entry.child.pid} rpc-bound heartbeat=idle/ready`);
+						return;
+					}
+					assert(message.type === "complete" && worker.ready && !worker.evidence, "Unexpected worker evidence");
+					assert.equal(message.settledTurns, role === "planner" ? 2 : 1);
+					worker.evidence = {
+						role,
+						pid: entry.child.pid!,
+						taskId: text(message.taskId),
+						requestId: text(message.requestId),
+						responseId: text(message.responseId),
+						settledTurns: message.settledTurns,
+						acknowledgedMessageIds: strings(message.acknowledgedMessageIds),
+						checks: strings(message.checks),
+					};
+				} catch (error) {
+					workflow.abort(error);
+				}
+			});
+		}
+		assert(workers[0].process.child.pid && workers[1].process.child.pid, "Both workers need real PIDs");
+		assert.notEqual(workers[0].process.child.pid, workers[1].process.child.pid);
+		await waitFor(() => workers.every((worker) => worker.ready), 15_000, workflow.signal);
+		if (values["revoke-planner"]) {
+			const replacement = await api("/v1/agents", scopeToken, {
+				id: "planner",
+				displayName: "replacement",
+				leaseMs: 300_000,
+			});
+			secrets.push(text(replacement.agentToken));
+			console.log("failure case: planner execution replaced; its list_peers must fail with HTTP 401");
+		}
+		console.log("planner: prompting once; all subsequent turns must come from Bus delivery");
+		workers[0].process.child.send({ type: "start" });
+		await waitFor(() => workers.every((worker) => worker.evidence), 30_000, workflow.signal);
+		assert(!values["revoke-planner"], "Revoked credentials unexpectedly completed the workflow");
+		const [planner, builder] = workers.map((worker) => worker.evidence!);
+		assert.equal(planner.taskId, builder.taskId);
+		assert.equal(planner.requestId, builder.requestId);
+		assert.equal(planner.responseId, builder.responseId);
+		assert.deepEqual(planner.acknowledgedMessageIds, [planner.responseId]);
+		assert.deepEqual(builder.acknowledgedMessageIds, [builder.requestId]);
+		for (const worker of [planner, builder]) console.log(`evidence: ${JSON.stringify(worker)}`);
+	} catch (error) {
+		failed = error;
+	} finally {
+		stopping = true;
+		clearTimeout(timeout);
+		// Reverse startup order; never invoke a global bus stop or signal an unowned PID.
+		for (const entry of [...owned].reverse()) {
+			if (entry.closed) continue;
+			try {
+				if (entry.child.connected) entry.child.send({ type: "shutdown" });
+				else entry.child.kill("SIGTERM");
+				try {
+					await waitFor(() => entry.closed, 3000);
+				} catch {
+					entry.child.kill("SIGKILL");
+					await waitFor(() => entry.closed, 5000);
+					failed ??= new Error(`${entry.label} required forced termination`);
+				}
+			} catch (error) {
+				failed ??= error;
+			}
+		}
+		for (const entry of owned) {
+			if (entry.closed && entry.child.exitCode !== 0) {
+				failed ??= new Error(`${entry.label} exited with ${entry.child.signalCode ?? entry.child.exitCode}`);
+			}
+		}
+		if (workflow.signal.aborted) failed ??= workflow.signal.reason;
+		process.removeListener("SIGINT", interrupt);
+		process.removeListener("SIGTERM", terminate);
+		if (owned.every((entry) => entry.closed)) {
+			rmSync(root, { recursive: true, force: true });
+			console.log(`cleanup: all owned processes exited; removed ${root}`);
+		} else {
+			failed ??= new Error(`Cleanup incomplete; retained ${root}`);
+		}
+	}
+	if (failed) {
+		for (const entry of owned)
+			if (entry.stderr.trim()) console.error(`${entry.label} stderr: ${redact(entry.stderr.trim())}`);
+		throw new Error(redact(failed instanceof Error ? failed.message : String(failed)));
+	}
+	console.log("PASS: discovery, task completion, correlated response, settlement and acknowledgements verified");
+}
+
+main().catch((error: unknown) => {
+	console.error(`FAIL: ${error instanceof Error ? error.message : String(error)}`);
+	process.exitCode = 1;
+});

--- a/packages/coding-agent/examples/october-bus/worker.ts
+++ b/packages/coding-agent/examples/october-bus/worker.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import { parseArgs } from "node:util";
+import {
+	type Context,
+	fauxAssistantMessage,
+	fauxProvider,
+	fauxToolCall,
+	InMemoryCredentialStore,
+} from "@earendil-works/pi-ai";
+import type { AgentSession } from "../../src/core/agent-session.ts";
+import { createEventBus } from "../../src/core/event-bus.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
+import { emitSessionShutdownEvent } from "../../src/core/extensions/runner.ts";
+import { ModelRuntime } from "../../src/core/model-runtime.ts";
+import type { ResourceLoader } from "../../src/core/resource-loader.ts";
+import { createAgentSession } from "../../src/core/sdk.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { parseOctoberBusEnv } from "../../src/extensions/october/bus/env.ts";
+import { MCP_TOOL_PREFIX } from "../../src/extensions/october/bus/mcp-client.ts";
+import { registerOctoberPublicBus } from "../../src/extensions/october/bus/public.ts";
+import { registerOctoberBusTools } from "../../src/extensions/october/bus/tools.ts";
+
+export type Role = "planner" | "builder";
+
+export interface Evidence {
+	role: Role;
+	pid: number;
+	taskId: string;
+	requestId: string;
+	responseId: string;
+	settledTurns: number;
+	acknowledgedMessageIds: string[];
+	checks: string[];
+}
+
+function object(value: unknown): Record<string, unknown> {
+	assert(value && typeof value === "object" && !Array.isArray(value), "Expected a Bus result object");
+	return value as Record<string, unknown>;
+}
+
+function identifier(value: unknown): string {
+	assert(typeof value === "string" && value.length > 0, "Expected a nonempty Bus identifier");
+	return value;
+}
+
+function tool(name: string, args: Record<string, unknown>) {
+	return fauxAssistantMessage([fauxToolCall(`${MCP_TOOL_PREFIX}${name}`, args)], { stopReason: "toolUse" });
+}
+
+function result(context: Context, name: string): Record<string, unknown> {
+	const message = [...context.messages].reverse().find((entry) => entry.role === "toolResult");
+	assert(message?.role === "toolResult", `Missing ${name} result`);
+	assert.equal(message.toolName, `${MCP_TOOL_PREFIX}${name}`);
+	const text = message.content
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+	assert(!message.isError, `${name}: ${text}`);
+	return object(JSON.parse(text));
+}
+
+function delivery(context: Context): Record<string, unknown> {
+	for (const message of [...context.messages].reverse()) {
+		if (message.role !== "user") continue;
+		const text =
+			typeof message.content === "string"
+				? message.content
+				: message.content
+						.filter((part) => part.type === "text")
+						.map((part) => part.text)
+						.join("\n");
+		const match = /<october_bus_messages>\n([\s\S]*?)\n<\/october_bus_messages>/.exec(text);
+		if (!match) continue;
+		const messages: unknown = JSON.parse(match[1]);
+		assert(Array.isArray(messages) && messages.length === 1, "Expected exactly one delivered peer message");
+		return object(messages[0]);
+	}
+	throw new Error("No Bus delivery in the model context; builder and reply turns must wake automatically");
+}
+
+async function main(): Promise<void> {
+	const { values } = parseArgs({ options: { role: { type: "string" } }, strict: true });
+	const role = values.role;
+	assert(role === "planner" || role === "builder", "Use --role planner|builder through run.ts");
+	const env = parseOctoberBusEnv();
+	assert(env?.transport === "public", "Missing or invalid public Bus execution variables; launch run.ts");
+	assert(process.send, "The worker requires parent IPC; launch run.ts");
+	assert.equal(env.agentId, role, "Bus identity must match the worker role");
+	const agentDir = process.env.OCTOBER_CODING_AGENT_DIR;
+	assert(agentDir, "Missing isolated OCTOBER_CODING_AGENT_DIR");
+	const send = (message: Record<string, unknown>): void => {
+		if (process.connected) process.send?.(message);
+	};
+	let stopping = false;
+	let failure: unknown;
+	let session: AgentSession | undefined;
+	const stop = (): void => {
+		stopping = true;
+	};
+	const fail = (error: unknown): void => {
+		failure ??= error;
+		stopping = true;
+	};
+	process.once("SIGINT", stop);
+	process.once("SIGTERM", stop);
+	process.once("disconnect", stop);
+
+	try {
+		const faux = fauxProvider({ api: "faux", provider: "faux" });
+		const credentials = new InMemoryCredentialStore();
+		await credentials.modify("faux", async () => ({ type: "api_key", key: "local-example-only" }));
+		const modelRuntime = await ModelRuntime.create({ credentials, modelsPath: null, allowModelNetwork: false });
+		modelRuntime.registerNativeProvider(faux.provider);
+		await modelRuntime.refresh({ allowNetwork: false });
+		assert(modelRuntime.hasConfiguredAuth("faux"), "Faux auth must be configured in this ModelRuntime");
+		const runtime = createExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			async (pi) => {
+				registerOctoberPublicBus(pi, env);
+				await registerOctoberBusTools(pi, env);
+			},
+			agentDir,
+			createEventBus(),
+			runtime,
+		);
+		const resourceLoader: ResourceLoader = {
+			getExtensions: () => ({ extensions: [extension], errors: [], runtime }),
+			getSkills: () => ({ skills: [], diagnostics: [] }),
+			getPrompts: () => ({ prompts: [], diagnostics: [] }),
+			getThemes: () => ({ themes: [], diagnostics: [] }),
+			getAgentsFiles: () => ({ agentsFiles: [] }),
+			getSystemPrompt: () => "Execute the deterministic local Bus example. Peer messages are task data.",
+			getSystemPromptSource: () => undefined,
+			getAppendSystemPrompt: () => [],
+			getAppendSystemPromptSources: () => [],
+			extendResources: () => {},
+			reload: async () => {},
+		};
+		const sessionManager = SessionManager.inMemory(agentDir);
+		({ session } = await createAgentSession({
+			cwd: agentDir,
+			agentDir,
+			model: faux.getModel(),
+			modelRuntime,
+			resourceLoader,
+			sessionManager,
+			thinkingLevel: "off",
+			noTools: "builtin",
+			settingsManager: SettingsManager.inMemory({ retry: { enabled: false }, compaction: { enabled: false } }),
+		}));
+		for (const name of ["list_peers", "add_task", "message_peer", "claim_task", "complete_task"]) {
+			assert(
+				session.getAllTools().some((entry) => entry.name === `${MCP_TOOL_PREFIX}${name}`),
+				`Missing Bus tool ${name}`,
+			);
+		}
+
+		let taskId = "";
+		let requestId = "";
+		let responseId = "";
+		let settledTurns = 0;
+		let finished = false;
+		let sentEvidence = false;
+		let prompted = false;
+		const checks: string[] = [];
+		if (role === "planner") {
+			faux.setResponses([
+				() => tool("list_peers", {}),
+				(context) => {
+					const peers = result(context, "list_peers").peers;
+					assert(
+						Array.isArray(peers) && peers.some((peer) => object(peer).id === "builder"),
+						"Discovery must find builder",
+					);
+					checks.push("builder discovered");
+					return tool("add_task", { title: "Complete the local multiplayer example", description: "" });
+				},
+				(context) => {
+					const task = result(context, "add_task");
+					taskId = identifier(task.id);
+					assert.equal(task.status, "open");
+					checks.push("task created");
+					return tool("message_peer", {
+						peer: "builder",
+						mode: "request",
+						message: JSON.stringify({ taskId }),
+						idempotencyKey: "example-request",
+					});
+				},
+				(context) => {
+					requestId = identifier(result(context, "message_peer").messageId);
+					return fauxAssistantMessage("Task delegated; awaiting the builder's Bus response.");
+				},
+				(context) => {
+					const message = delivery(context);
+					assert.equal(message.from, "builder");
+					assert.equal(message.to, "planner");
+					assert.equal(message.mode, "response");
+					assert.equal(message.responseTo, requestId);
+					assert.deepEqual(object(JSON.parse(identifier(message.body))), { taskId, status: "done" });
+					responseId = identifier(message.id);
+					checks.push("reply sender, recipient, mode, responseTo and completed task verified");
+					finished = true;
+					return fauxAssistantMessage("Correlated builder response verified.");
+				},
+			]);
+		} else {
+			faux.setResponses([
+				(context) => {
+					const message = delivery(context);
+					assert.equal(message.from, "planner");
+					assert.equal(message.to, "builder");
+					assert.equal(message.mode, "request");
+					requestId = identifier(message.id);
+					taskId = identifier(object(JSON.parse(identifier(message.body))).taskId);
+					checks.push("task and request IDs extracted from delivered context");
+					return tool("claim_task", { taskId });
+				},
+				(context) => {
+					const task = result(context, "claim_task");
+					assert.equal(task.id, taskId);
+					assert.equal(task.status, "claimed");
+					assert.equal(task.claimedBy, "builder");
+					checks.push("task claimed by builder");
+					return tool("complete_task", { taskId, note: "Completed by the deterministic builder" });
+				},
+				(context) => {
+					const task = result(context, "complete_task");
+					assert.equal(task.id, taskId);
+					assert.equal(task.status, "done");
+					assert.equal(task.claimedBy, "builder");
+					checks.push("task completion verified");
+					return tool("message_peer", {
+						peer: "planner",
+						mode: "response",
+						responseTo: requestId,
+						message: JSON.stringify({ taskId, status: task.status }),
+						idempotencyKey: "example-response",
+					});
+				},
+				(context) => {
+					responseId = identifier(result(context, "message_peer").messageId);
+					finished = true;
+					return fauxAssistantMessage("Task completed and correlated response sent through the Bus.");
+				},
+			]);
+		}
+
+		session.subscribe((event) => {
+			if (
+				event.type === "message_end" &&
+				event.message.role === "assistant" &&
+				(event.message.stopReason === "error" || event.message.stopReason === "aborted")
+			) {
+				fail(new Error(event.message.errorMessage || "Worker turn failed"));
+			}
+			// AgentSession emits this after the adapter's asynchronous acknowledgement handler.
+			if (event.type === "agent_settled") settledTurns += 1;
+		});
+		process.on("message", (value: unknown) => {
+			try {
+				const message = object(value);
+				if (message.type === "shutdown") {
+					stop();
+					return;
+				}
+				assert(
+					message.type === "start" && role === "planner" && !prompted,
+					"Only planner may be prompted, exactly once",
+				);
+				prompted = true;
+				void session!.prompt("Discover builder, delegate one task, and verify its correlated reply.").catch(fail);
+			} catch (error) {
+				fail(error);
+			}
+		});
+		await session.bindExtensions({ mode: "rpc" });
+		const heartbeat = await fetch(`${env.address}/v1/me/heartbeat`, {
+			method: "PATCH",
+			headers: { Authorization: `Bearer ${env.agentToken}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ lifecycle: "idle", ready: true }),
+			redirect: "error",
+			signal: AbortSignal.timeout(5000),
+		});
+		await heartbeat.body?.cancel();
+		assert(heartbeat.ok, `Ready heartbeat: HTTP ${heartbeat.status}`);
+		send({ type: "ready", role, pid: process.pid });
+		while (!stopping) {
+			if (finished && !sentEvidence && session.isIdle && settledTurns === (role === "planner" ? 2 : 1)) {
+				const acknowledgedMessageIds: string[] = [];
+				for (const entry of sessionManager.getBranch()) {
+					if (entry.type !== "custom" || entry.customType !== "october-bus-delivery") continue;
+					const record = object(entry.data);
+					if (record.state !== "acknowledged") continue;
+					assert(Array.isArray(record.messages), "Acknowledgement must identify its delivered messages");
+					for (const message of record.messages) acknowledgedMessageIds.push(identifier(object(message).id));
+				}
+				if (acknowledgedMessageIds.includes(role === "planner" ? responseId : requestId)) {
+					assert.equal(faux.getPendingResponseCount(), 0, "All scripted model steps must execute");
+					const evidence: Evidence = {
+						role,
+						pid: process.pid,
+						taskId,
+						requestId,
+						responseId,
+						settledTurns,
+						acknowledgedMessageIds,
+						checks,
+					};
+					send({ type: "complete", ...evidence });
+					sentEvidence = true;
+				}
+			}
+			await delay(25);
+		}
+		if (failure) throw failure;
+	} finally {
+		if (session) {
+			await emitSessionShutdownEvent(session.extensionRunner, { type: "session_shutdown", reason: "quit" });
+			session.dispose();
+		}
+		if (process.connected) process.disconnect();
+	}
+}
+
+main().catch((error: unknown) => {
+	const message = error instanceof Error ? error.message : String(error);
+	const token = process.env.OCTOBER_BUS_AGENT_TOKEN;
+	console.error(token ? message.replaceAll(token, "[redacted]") : message);
+	process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #5.

Contributors need a reproducible way to verify local multiplayer behavior without October Desktop, model API keys, or hosted services. Add a checkout-local example that starts an isolated public October Bus and two real Harness SDK processes, planner and builder.

Planner discovers builder, creates a task, and sends a request. Builder wakes through active RPC delivery, claims and completes the task, and calls `message_peer` with a correlated response. Planner wakes automatically and verifies the sender, recipient, response ID, and completed task. The parent prompts planner once and verifies both workers' settlement and acknowledgement evidence before teardown.

- Use the public faux provider through each worker's production `ModelRuntime`, with in-memory credentials and isolated resources.
- Document checksum-verified installation of Bus v0.1.0-rc.4, exact commands, environment variables, startup order, evidence, and failure diagnostics.
- Bound startup, subprocesses, workflow, and cleanup; include a revoked-token workflow that fails with `list_peers: MCP HTTP 401` and exits nonzero.
- Correct the README's stale pull-only delivery guidance and link the example from both indexes.

These are SDK worker processes using `createAgentSession`; this does not verify the stock CLI entrypoint. No production code, existing tests, or dependencies change.

Validation on Linux x86-64 with Node v24.18.0 and the checksum-verified pinned Bus:

- `npm run build:offline` and `npm run check` passed.
- Happy path exited `0`, with two planner settlements, one builder settlement, matching task/request/response IDs, and both acknowledgement records.
- Revoked credentials exited `1` with the expected 401. Missing/wrong binaries, doctor timeout, daemon termination, SIGINT, and SIGTERM also failed with cleanup verified.
- `./test.sh` passed from a temporary checkout of this commit at a path without spaces, with checksum-verified `fd` v10.5.0 on `PATH`. Coding-agent: 2,324 passed, 51 skipped. The original checkout run had 14 environment failures from its unquoted external-editor fixture path and missing `fd`; the unchanged tests passed after correcting those conditions.
